### PR TITLE
Create Image-to-sketch.py

### DIFF
--- a/Python Programs/Image-to-sketch.py
+++ b/Python Programs/Image-to-sketch.py
@@ -1,0 +1,39 @@
+import cv2
+import matplotlib.pyplot as plt
+plt.style.use('seaborn')
+
+img = cv2.imread("image1.png")
+img = cv2.cvtColor(img,cv2.COLOR_BGR2RGB)
+plt.figure(figsize=(8,8))
+plt.imshow(img)
+plt.axis("off")
+plt.title("Original Image")
+plt.show()
+
+img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+plt.figure(figsize=(8,8))
+plt.imshow(img_gray,cmap="gray")
+plt.axis("off")
+plt.title("GrayScale Image")
+plt.show()
+
+img_invert = cv2.bitwise_not(img_gray)
+plt.figure(figsize=(8,8))
+plt.imshow(img_invert,cmap="gray")
+plt.axis("off")
+plt.title("Inverted Image")
+plt.show()
+
+img_smoothing = cv2.GaussianBlur(img_invert, (21, 21),sigmaX=0, sigmaY=0)
+plt.figure(figsize=(8,8))
+plt.imshow(img_smoothing,cmap="gray")
+plt.axis("off")
+plt.title("Smoothen Image")
+plt.show()
+
+final = cv2.divide(img_gray, 255 - img_smoothing, scale=255)
+plt.figure(figsize=(8,8))
+plt.imshow(final,cmap="gray")
+plt.axis("off")
+plt.title("Final Sketch Image")
+plt.show()


### PR DESCRIPTION
This python code uses computer vision library OpenCV, for converting any image to pencil sketch easily. Sample image has been provided for reference.
![aaaa](https://user-images.githubusercontent.com/77789927/194389608-7133e528-df00-4f74-971b-030930cc1faa.png)
